### PR TITLE
Fix pixel function selection

### DIFF
--- a/src/cgifh.c
+++ b/src/cgifh.c
@@ -173,6 +173,18 @@ static inline cgifh_pixel_fn cgifh_get_px_fn(
 	int clip_x1 = img->width;
 	int clip_y1 = img->height;
 
+	if (test_x0 > test_x1) {
+		int tmp = test_x0;
+		test_x0 = test_x1;
+		test_x1 = tmp;
+	}
+
+	if (test_y0 > test_y1) {
+		int tmp = test_y0;
+		test_y0 = test_y1;
+		test_y1 = tmp;
+	}
+
 	if (test_x0 >= clip_x0 &&
 	    test_x1 <  clip_x1 &&
 	    test_y0 >= clip_y0 &&


### PR DESCRIPTION
A "safe" pixel plotting function is used if the thing being plotted goes out the screen. Previously the code which decides which to use assumed that the first bounding box coordinate was nearer the origin than the second bounding box coordinate.

Now we don't care what order they're in, making the library easier to use.